### PR TITLE
Switch eventing to use Mjolnir-based event proxy

### DIFF
--- a/bench/lib/mouse_events.js
+++ b/bench/lib/mouse_events.js
@@ -4,7 +4,7 @@ module.exports = function(map) {
   events.push = function(event, point, dp) {
     var payload = {
       dropPoint: dp === undefined ? false : dp,
-      originalEvent: {
+      srcEvent: {
         isShiftKey: false,
         stopPropagation: function() {}
       },

--- a/src/events.js
+++ b/src/events.js
@@ -127,8 +127,6 @@ module.exports = function(ctx) {
   const isKeyModeValid = (code) => !(code === 8 || code === 46 || (code >= 48 && code <= 57));
 
   events.keydown = function(event) {
-    if ((event.srcElement || event.target).classList[0] !== 'mapboxgl-canvas') return; // we only handle events on the map
-
     if ((event.keyCode === 8 || event.keyCode === 46) && ctx.options.controls.trash) {
       event.preventDefault();
       currentMode.trash();
@@ -229,11 +227,11 @@ module.exports = function(ctx) {
       eventProxy.on('touchstart', events.touchstart);
       eventProxy.on('touchend', events.touchend);
 
-      ctx.container.addEventListener('mouseout', events.mouseout);
+      document.addEventListener('mouseout', events.mouseout);
 
       if (ctx.options.keybindings) {
-        ctx.container.addEventListener('keydown', events.keydown);
-        ctx.container.addEventListener('keyup', events.keyup);
+        document.addEventListener('keydown', events.keydown);
+        document.addEventListener('keyup', events.keyup);
       }
     },
     removeEventListeners: function() {
@@ -247,11 +245,11 @@ module.exports = function(ctx) {
       eventProxy.off('touchstart', events.touchstart);
       eventProxy.off('touchend', events.touchend);
 
-      ctx.container.removeEventListener('mouseout', events.mouseout);
+      document.removeEventListener('mouseout', events.mouseout);
 
       if (ctx.options.keybindings) {
-        ctx.container.removeEventListener('keydown', events.keydown);
-        ctx.container.removeEventListener('keyup', events.keyup);
+        document.removeEventListener('keydown', events.keydown);
+        document.removeEventListener('keyup', events.keyup);
       }
     },
     trash: function(options) {

--- a/src/events.js
+++ b/src/events.js
@@ -27,7 +27,7 @@ module.exports = function(ctx) {
       ctx.ui.queueMapClasses({ mouse: Constants.cursors.DRAG });
       currentMode.drag(event);
     } else {
-      event.originalEvent.stopPropagation();
+      event.srcEvent.stopPropagation();
     }
   };
 
@@ -40,7 +40,7 @@ module.exports = function(ctx) {
   };
 
   events.mousemove = function(event) {
-    const button = event.originalEvent.buttons !== undefined ? event.originalEvent.buttons : event.originalEvent.which;
+    const button = event.srcEvent.buttons !== undefined ? event.srcEvent.buttons : event.srcEvent.which;
     if (button === 1) {
       return events.mousedrag(event);
     }
@@ -80,7 +80,7 @@ module.exports = function(ctx) {
   events.touchstart = function(event) {
     // Prevent emulated mouse events because we will fully handle the touch here.
     // This does not stop the touch events from propogating to mapbox though.
-    event.originalEvent.preventDefault();
+    event.srcEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -95,7 +95,7 @@ module.exports = function(ctx) {
   };
 
   events.touchmove = function(event) {
-    event.originalEvent.preventDefault();
+    event.srcEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -105,7 +105,7 @@ module.exports = function(ctx) {
   };
 
   events.touchend = function(event) {
-    event.originalEvent.preventDefault();
+    event.srcEvent.preventDefault();
     if (!ctx.options.touchEnabled) {
       return;
     }
@@ -219,14 +219,15 @@ module.exports = function(ctx) {
       }
     },
     addEventListeners: function() {
-      ctx.map.on('mousemove', events.mousemove);
-      ctx.map.on('mousedown', events.mousedown);
-      ctx.map.on('mouseup', events.mouseup);
-      ctx.map.on('data', events.data);
+      const eventProxy = ctx.options.eventProxy || ctx.map;
+      eventProxy.on('mousemove', events.mousemove);
+      eventProxy.on('mousedown', events.mousedown);
+      eventProxy.on('mouseup', events.mouseup);
+      eventProxy.on('data', events.data);
 
-      ctx.map.on('touchmove', events.touchmove);
-      ctx.map.on('touchstart', events.touchstart);
-      ctx.map.on('touchend', events.touchend);
+      eventProxy.on('touchmove', events.touchmove);
+      eventProxy.on('touchstart', events.touchstart);
+      eventProxy.on('touchend', events.touchend);
 
       ctx.container.addEventListener('mouseout', events.mouseout);
 
@@ -236,14 +237,15 @@ module.exports = function(ctx) {
       }
     },
     removeEventListeners: function() {
-      ctx.map.off('mousemove', events.mousemove);
-      ctx.map.off('mousedown', events.mousedown);
-      ctx.map.off('mouseup', events.mouseup);
-      ctx.map.off('data', events.data);
+      const eventProxy = ctx.options.eventProxy || ctx.map;
+      eventProxy.off('mousemove', events.mousemove);
+      eventProxy.off('mousedown', events.mousedown);
+      eventProxy.off('mouseup', events.mouseup);
+      eventProxy.off('data', events.data);
 
-      ctx.map.off('touchmove', events.touchmove);
-      ctx.map.off('touchstart', events.touchstart);
-      ctx.map.off('touchend', events.touchend);
+      eventProxy.off('touchmove', events.touchmove);
+      eventProxy.off('touchstart', events.touchstart);
+      eventProxy.off('touchend', events.touchend);
 
       ctx.container.removeEventListener('mouseout', events.mouseout);
 

--- a/src/lib/common_selectors.js
+++ b/src/lib/common_selectors.js
@@ -10,9 +10,9 @@ module.exports = {
     };
   },
   isShiftMousedown: function(e) {
-    if (!e.originalEvent) return false;
-    if (!e.originalEvent.shiftKey) return false;
-    return e.originalEvent.button === 0;
+    if (!e.srcEvent) return false;
+    if (!e.srcEvent.shiftKey) return false;
+    return e.srcEvent.button === 0;
   },
   isActiveFeature: function(e) {
     if (!e.featureTarget) return false;
@@ -41,8 +41,8 @@ module.exports = {
     return featureTarget.properties.meta === Constants.meta.VERTEX;
   },
   isShiftDown: function(e) {
-    if (!e.originalEvent) return false;
-    return e.originalEvent.shiftKey === true;
+    if (!e.srcEvent) return false;
+    return e.srcEvent.shiftKey === true;
   },
   isEscapeKey: function(e) {
     return e.keyCode === 27;

--- a/src/lib/is_event_at_coordinates.js
+++ b/src/lib/is_event_at_coordinates.js
@@ -1,6 +1,6 @@
 function isEventAtCoordinates(event, coordinates) {
-  if (!event.lngLat) return false;
-  return event.lngLat.lng === coordinates[0] && event.lngLat.lat === coordinates[1];
+  if (!event.latLng) return false;
+  return event.latLng[1] === coordinates[0] && event.latLng[0] === coordinates[1];
 }
 
 module.exports = isEventAtCoordinates;

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -31,7 +31,8 @@ DirectSelect.fireActionable = function(state) {
 DirectSelect.startDragging = function(state, e) {
   this.map.dragPan.disable();
   state.canDragMove = true;
-  state.dragMoveLocation = e.lngLat;
+  const [lat, lng] = e.latLng;
+  state.dragMoveLocation = {lng, lat};
 };
 
 DirectSelect.stopDragging = function(state) {
@@ -74,7 +75,8 @@ DirectSelect.onFeature = function(state, e) {
 
 DirectSelect.dragFeature = function(state, e, delta) {
   moveFeatures(this.getSelected(), delta);
-  state.dragMoveLocation = e.lngLat;
+  const [lat, lng] = e.latLng;
+  state.dragMoveLocation = {lng, lat};
 };
 
 DirectSelect.dragVertex = function(state, e, delta) {
@@ -201,16 +203,16 @@ DirectSelect.onTouchStart = DirectSelect.onMouseDown = function(state, e) {
 DirectSelect.onDrag = function(state, e) {
   if (state.canDragMove !== true) return;
   state.dragMoving = true;
-  e.originalEvent.stopPropagation();
-
+  e.srcEvent.stopPropagation();
+  const [lat, lng] = e.latLng;
   const delta = {
-    lng: e.lngLat.lng - state.dragMoveLocation.lng,
-    lat: e.lngLat.lat - state.dragMoveLocation.lat
+    lng: lng - state.dragMoveLocation.lng,
+    lat: lat - state.dragMoveLocation.lat
   };
   if (state.selectedCoordPaths.length > 0) this.dragVertex(state, e, delta);
   else this.dragFeature(state, e, delta);
 
-  state.dragMoveLocation = e.lngLat;
+  state.dragMoveLocation = {lng, lat};
 };
 
 DirectSelect.onClick = function(state, e) {

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -74,12 +74,13 @@ DrawLineString.clickAnywhere = function(state, e) {
     return this.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [state.line.id] });
   }
   this.updateUIClasses({ mouse: Constants.cursors.ADD });
-  state.line.updateCoordinate(state.currentVertexPosition, e.lngLat.lng, e.lngLat.lat);
+  const [lat, lng] = e.latLng;
+  state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
   if (state.direction === 'forward') {
     state.currentVertexPosition++;
-    state.line.updateCoordinate(state.currentVertexPosition, e.lngLat.lng, e.lngLat.lat);
+    state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
   } else {
-    state.line.addCoordinate(0, e.lngLat.lng, e.lngLat.lat);
+    state.line.addCoordinate(0, lng, lat);
   }
 };
 
@@ -88,7 +89,8 @@ DrawLineString.clickOnVertex = function(state) {
 };
 
 DrawLineString.onMouseMove = function(state, e) {
-  state.line.updateCoordinate(state.currentVertexPosition, e.lngLat.lng, e.lngLat.lat);
+  const [lat, lng] = e.latLng;
+  state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
   if (CommonSelectors.isVertex(e)) {
     this.updateUIClasses({ mouse: Constants.cursors.POINTER });
   }

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -32,8 +32,9 @@ DrawPoint.stopDrawingAndRemove = function(state) {
 };
 
 DrawPoint.onTap = DrawPoint.onClick = function(state, e) {
+  const [lat, lng] = e.latLng;
   this.updateUIClasses({ mouse: Constants.cursors.MOVE });
-  state.point.updateCoordinate('', e.lngLat.lng, e.lngLat.lat);
+  state.point.updateCoordinate('', lng, lat);
   this.map.fire(Constants.events.CREATE, {
     features: [state.point.toGeoJSON()]
   });

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -37,9 +37,10 @@ DrawPolygon.clickAnywhere = function(state, e) {
     return this.changeMode(Constants.modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
   }
   this.updateUIClasses({ mouse: Constants.cursors.ADD });
-  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+  const [lat, lng] = e.latLng;
+  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, lng, lat);
   state.currentVertexPosition++;
-  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, lng, lat);
 };
 
 DrawPolygon.clickOnVertex = function(state) {
@@ -47,7 +48,8 @@ DrawPolygon.clickOnVertex = function(state) {
 };
 
 DrawPolygon.onMouseMove = function(state, e) {
-  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+  const [lat, lng] = e.latLng;
+  state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, lng, lat);
   if (CommonSelectors.isVertex(e)) {
     this.updateUIClasses({ mouse: Constants.cursors.POINTER });
   }

--- a/src/modes/mode_interface_accessors.js
+++ b/src/modes/mode_interface_accessors.js
@@ -7,7 +7,7 @@ const MultiFeature = require('../feature_types/multi_feature');
 
 const ModeInterface = module.exports = function(ctx) {
   this.map = ctx.map;
-  this.drawConfig = JSON.parse(JSON.stringify(ctx.options || {}));
+  this.drawConfig = JSON.parse(JSON.stringify(Object.assign({}, ctx.options, { eventProxy: undefined }) || {}));
   this._ctx = ctx;
 };
 


### PR DESCRIPTION
Our React-wrapped Mapbox map uses Mjolnir for eventing and swallows the Mapbox events that `mapbox-gl-draw` is expecting. To get around this we pass an event proxy to receive events from here, and modify handlers slightly to take Mjolnir events instead of Mapbox events.