### PR TITLE
Access store features from the draw.render event

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -80,7 +80,9 @@ module.exports = function render() {
   }
 
   cleanup();
-  store.ctx.map.fire(Constants.events.RENDER, {});
+  store.ctx.map.fire(Constants.events.RENDER, {
+    getAllFeatures: () => store.getAll()
+  });
 
   function cleanup() {
     store.isDirty = false;


### PR DESCRIPTION
This allows us to "pre-select" matching features in the lasso tool while
the user draws the polygon.

The current implementation forces the user to finish the drawing to
receive a geometry.

With this change, we could hover the features before selecting them, and
keep the candidate features in a reference to select them later.

![select on the fly](https://user-images.githubusercontent.com/594302/73892128-deae1b80-482a-11ea-8541-9f8a36e2f49a.gif)

