### PR TITLE
Change dragPan mechanism

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -192,5 +192,11 @@ module.exports = function(ctx, api) {
     return api;
   };
 
+  // We can't just call dragPan on the map because react component
+  // implements its own panning. So notify caller to do something.
+  api.setOnAllowDragPanChanged = function(callback) {
+      ctx.externalHooks.onAllowDragPanChanged = callback;
+  };
+
   return api;
 };

--- a/src/modes/direct_select.js
+++ b/src/modes/direct_select.js
@@ -29,14 +29,18 @@ DirectSelect.fireActionable = function(state) {
 };
 
 DirectSelect.startDragging = function(state, e) {
-  this.map.dragPan.disable();
+  if (this._ctx.externalHooks.onAllowDragPanChanged) {
+    this._ctx.externalHooks.onAllowDragPanChanged(false);
+  }
   state.canDragMove = true;
   const [lat, lng] = e.latLng;
   state.dragMoveLocation = {lng, lat};
 };
 
 DirectSelect.stopDragging = function(state) {
-  this.map.dragPan.enable();
+  if (this._ctx.externalHooks.onAllowDragPanChanged) {
+    this._ctx.externalHooks.onAllowDragPanChanged(true);
+  }
   state.dragMoving = false;
   state.canDragMove = false;
   state.dragMoveLocation = null;

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -87,7 +87,9 @@ SimpleSelect.stopExtendedInteractions = function(state) {
     state.boxSelectElement = null;
   }
 
-  this.map.dragPan.enable();
+  if (this._ctx.externalHooks.onAllowDragPanChanged) {
+    this._ctx.externalHooks.onAllowDragPanChanged(true);
+  }
 
   state.boxSelecting = false;
   state.canBoxSelect = false;
@@ -147,7 +149,9 @@ SimpleSelect.startOnActiveFeature = function(state, e) {
   this.stopExtendedInteractions(state);
 
   // Disable map.dragPan immediately so it can't start
-  this.map.dragPan.disable();
+  if (this._ctx.externalHooks.onAllowDragPanChanged) {
+    this._ctx.externalHooks.onAllowDragPanChanged(false);
+  }
 
   // Re-render it and enable drag move
   this.doRender(e.featureTarget.properties.id);
@@ -208,7 +212,9 @@ SimpleSelect.onMouseDown = function(state, e) {
 
 SimpleSelect.startBoxSelect = function(state, e) {
   this.stopExtendedInteractions(state);
-  this.map.dragPan.disable();
+  if (this._ctx.externalHooks.onAllowDragPanChanged) {
+    this._ctx.externalHooks.onAllowDragPanChanged(false);
+  }
   // Enable box select
   state.boxSelectStartLocation = mouseEventPoint(e.srcEvent, this.map.getContainer());
   state.canBoxSelect = true;

--- a/src/setup.js
+++ b/src/setup.js
@@ -57,16 +57,13 @@ module.exports = function(ctx) {
       ctx.ui = ui(ctx);
       ctx.container = map.getContainer();
       ctx.store = new Store(ctx);
+      ctx.externalHooks = {};
 
 
       controlContainer = ctx.ui.addButtons();
 
       if (ctx.options.boxSelect) {
         map.boxZoom.disable();
-        // Need to toggle dragPan on and off or else first
-        // dragPan disable attempt in simple_select doesn't work
-        map.dragPan.disable();
-        map.dragPan.enable();
       }
 
       if (map.loaded()) {
@@ -121,7 +118,7 @@ module.exports = function(ctx) {
       if (ctx.map.getSource(Constants.sources.HOT)) {
         ctx.map.removeSource(Constants.sources.HOT);
       }
-    }
+    },
   };
 
   ctx.setup = setup;


### PR DESCRIPTION
mapbox-gl-draw sometimes calls `map.dragPan.enable()` and `map.dragPan.disable()`, which operates on the non-react mapbox map. However, the react mapbox wrapper implements its own dragPan functionality and expects the non-react logic to be disabled.

We remove the calls to the non-react map and instead provide a hook system.