### PR TITLE
Exit early in some situations when the control has been removed

### DIFF
--- a/src/lib/mode_handler.js
+++ b/src/lib/mode_handler.js
@@ -59,6 +59,10 @@ const ModeHandler = function(mode, DrawContext) {
     trash: function() {
       if (mode.trash) {
         mode.trash();
+        // The trashing could have caused the control to unload
+        if (!DrawContext.store) {
+          return;
+        }
         DrawContext.store.render();
       }
     },

--- a/src/render.js
+++ b/src/render.js
@@ -2,8 +2,12 @@ const Constants = require('./constants');
 
 module.exports = function render() {
   const store = this;
-  const mapExists = store.ctx.map && store.ctx.map.getSource(Constants.sources.HOT) !== undefined;
-  if (!mapExists) return cleanup();
+
+  function mapExists() {
+    return store.ctx.map && store.ctx.map.getSource(Constants.sources.HOT) !== undefined;
+  }
+
+  if (!mapExists()) return cleanup();
 
   const mode = store.ctx.events.currentModeName();
 
@@ -77,6 +81,9 @@ module.exports = function render() {
     store.ctx.map.fire(Constants.events.DELETE, {
       features: geojsonToEmit
     });
+
+    // Firing the delete event could have caused the control to be unloaded
+    if (!mapExists()) return cleanup();
   }
 
   cleanup();


### PR DESCRIPTION
There are some cases where the control might get removed while a function is still running.

For example, the render function fires off the event `Constants.events.DELETE`, and the event handling might cause the control to get removed. If this is the case, then trying to fire a render event later on in the render function would fail. Instead, when the control did get removed, we should clean up and exit early.

Similarly, after calling `trash` on the mode, the control might have gotten removed. So check for that case and exit early if so.